### PR TITLE
update go 1.19.1

### DIFF
--- a/.github/workflows/client-js-test.yaml
+++ b/.github/workflows/client-js-test.yaml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      go-version: 1.18.3
+      go-version: 1.19.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.3
+          go-version: 1.19.1
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      go-version: 1.18.3
+      go-version: 1.19.1
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     name: Server test
 
     runs-on: ubuntu-latest
-    container: golang:1.18.3-bullseye
+    container: golang:1.19.1-bullseye
     services:
       redis:
         image: redis:6.0.9
@@ -88,7 +88,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      go-version: 1.18.3
+      go-version: 1.19.1
 
     steps:
       - uses: actions/checkout@v2

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.3
+FROM golang:1.19.1
 ARG DSPS_VERSION_ID=""
 WORKDIR /go/src/github.com/dsps/server
 COPY . .

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -57,9 +56,9 @@ func LoadConfigFile(ctx context.Context, configFile string, configOverrides Over
 	case "":
 		yamlBytes = []byte("")
 	case "-":
-		yamlBytes, err = ioutil.ReadAll(os.Stdin)
+		yamlBytes, err = io.ReadAll(os.Stdin)
 	default:
-		yamlBytes, err = ioutil.ReadFile(configFile) //nolint:gosec // Disables G304: Potential file inclusion via variable
+		yamlBytes, err = os.ReadFile(configFile) //nolint:gosec // Disables G304: Potential file inclusion via variable
 	}
 	if err != nil {
 		return ServerConfig{}, err

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/m3dev/dsps/server
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go v0.74.0 // indirect

--- a/server/http/middleware/logger_test.go
+++ b/server/http/middleware/logger_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -132,7 +132,7 @@ func TestPanicHandling(t *testing.T) {
 		logger.WithTestLogger(t, nil, func(lc *logger.LogCapture) {
 			res := DoHTTPRequest(t, "GET", server.URL+"/panic-after-200", ``)
 			assert.Equal(t, 200, res.StatusCode) // After response sent.
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, `{"hi":"hello"}`+"\n", string(body))
 			assert.NoError(t, res.Body.Close())

--- a/server/http/router/request.go
+++ b/server/http/router/request.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -14,7 +14,7 @@ type Request struct {
 func (req Request) ReadBody() ([]byte, error) {
 	// > The Server will close the request body. The ServeHTTP Handler does not need to.
 	// https://golang.org/pkg/net/http/#ResponseWriter
-	return ioutil.ReadAll(req.Body)
+	return io.ReadAll(req.Body)
 }
 
 // GetQueryParam returns URL query parameter or ""

--- a/server/http/testing/http_response.go
+++ b/server/http/testing/http_response.go
@@ -2,7 +2,7 @@ package testing
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -52,7 +52,7 @@ func BodyJSONMapOfRes(t *testing.T, res *http.Response) map[string]interface{} {
 func BodyJSONOfRes(t *testing.T, res *http.Response, body interface{}) {
 	assert.Regexp(t, "application/json(;|$)", res.Header.Get("Content-Type"))
 
-	raw, err := ioutil.ReadAll(res.Body)
+	raw, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.NoError(t, res.Body.Close())
 	assert.NoError(t, json.Unmarshal(raw, body), "failed to parse response JSON: %s", string(raw))

--- a/server/jwt/signing_key.go
+++ b/server/jwt/signing_key.go
@@ -2,7 +2,7 @@ package jwt
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	jwtgo "github.com/dgrijalva/jwt-go/v4"
 
@@ -27,7 +27,7 @@ func LoadKey(alg domain.JwtAlg, keyFilePath string, privateKey bool) (interface{
 	}
 
 	parserWrapper := func(f func(bytes []byte) (interface{}, error)) (interface{}, error) {
-		bytes, err := ioutil.ReadFile(keyFilePath) //nolint:gosec // Only loads file specified by server configuration file
+		bytes, err := os.ReadFile(keyFilePath) //nolint:gosec // Only loads file specified by server configuration file
 		if err != nil {
 			return nil, fmt.Errorf(`failed to read JWT key file "%s": %w`, keyFilePath, err)
 		}

--- a/server/jwt/validator/validator_test.go
+++ b/server/jwt/validator/validator_test.go
@@ -2,7 +2,8 @@ package validator_test
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
+
 	"testing"
 	"time"
 
@@ -38,12 +39,12 @@ func TestPregeneratedJwt(t *testing.T) {
 	v := createDefaultValidator(t)
 
 	// Valid JWT
-	jwt, err := ioutil.ReadFile("../testdata/RS256-2048bit.jwt")
+	jwt, err := os.ReadFile("../testdata/RS256-2048bit.jwt")
 	assert.NoError(t, err)
 	assert.NoError(t, v.Validate(ctx, string(jwt)))
 
 	// Expired JWT
-	jwt, err = ioutil.ReadFile("../testdata/RS256-2048bit-expired.jwt")
+	jwt, err = os.ReadFile("../testdata/RS256-2048bit-expired.jwt")
 	assert.NoError(t, err)
 	err = v.Validate(ctx, string(jwt))
 	assert.Error(t, err)

--- a/server/testing/file_utils.go
+++ b/server/testing/file_utils.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -10,10 +9,10 @@ import (
 
 // WithTextFile creates temporary text file
 func WithTextFile(t *testing.T, content string, f func(filename string)) {
-	file, err := ioutil.TempFile(os.TempDir(), "dsps-test-*.txt")
+	file, err := os.CreateTemp(os.TempDir(), "dsps-test-*.txt")
 	assert.NoError(t, err)
 	defer assert.NoError(t, os.Remove(file.Name()))
 
-	assert.NoError(t, ioutil.WriteFile(file.Name(), []byte(content), os.ModePerm))
+	assert.NoError(t, os.WriteFile(file.Name(), []byte(content), os.ModePerm))
 	f(file.Name())
 }

--- a/server/webhook/outgoing/client_multiplexer_test.go
+++ b/server/webhook/outgoing/client_multiplexer_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -21,7 +21,7 @@ func TestNewMultiplexClient(t *testing.T) {
 	received := []domain.Message{}
 	responseCodes := []int{}
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		bytes, err := ioutil.ReadAll(r.Body)
+		bytes, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		var msg domain.Message
 		assert.NoError(t, json.Unmarshal(bytes, &msg))

--- a/server/webhook/outgoing/client_test.go
+++ b/server/webhook/outgoing/client_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -52,7 +52,7 @@ func TestClientImpl(t *testing.T) {
 		assert.Equal(t, `My DSPS server`, r.Header.Get("User-Agent"))
 		assert.Equal(t, `1234`, r.Header.Get("X-Room-ID"))
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("%d", len(body)), r.Header.Get("Content-Length"))
 		assert.NoError(t, json.Unmarshal(body, &received))
@@ -63,9 +63,9 @@ func TestClientImpl(t *testing.T) {
 		map[string]interface{}{"channel": map[string]string{"id": "1234"}},
 		`{
 			"method": "PUT",
-			"url": "${BASE_URL}/you-got-message/room/{{.channel.id}}", 
+			"url": "${BASE_URL}/you-got-message/room/{{.channel.id}}",
 			"timeout": "3s",
-			"headers": { 
+			"headers": {
 				"User-Agent": "My DSPS server",
 				"X-Room-ID": "{{.channel.id}}"
 			}
@@ -93,7 +93,7 @@ func TestClientTracing(t *testing.T) {
 		assert.Equal(t, `My DSPS server`, r.Header.Get("User-Agent"))
 		assert.Equal(t, `1234`, r.Header.Get("X-Room-ID"))
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("%d", len(body)), r.Header.Get("Content-Length"))
 		assert.NoError(t, json.Unmarshal(body, &received))
@@ -106,9 +106,9 @@ func TestClientTracing(t *testing.T) {
 			map[string]interface{}{"channel": map[string]string{"id": "1234"}},
 			`{
 				"method": "PUT",
-				"url": "${BASE_URL}/you-got-message/room/{{.channel.id}}", 
+				"url": "${BASE_URL}/you-got-message/room/{{.channel.id}}",
 				"timeout": "3s",
-				"headers": { 
+				"headers": {
 					"User-Agent": "My DSPS server",
 					"X-Room-ID": "{{.channel.id}}"
 				}
@@ -156,7 +156,7 @@ func TestClientRetry(t *testing.T) {
 		assert.Equal(t, "PUT", r.Method)
 		assert.Equal(t, `/you-got-message/room/1234`, r.URL.Path)
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.NoError(t, json.Unmarshal(body, &received))
 	}
@@ -166,7 +166,7 @@ func TestClientRetry(t *testing.T) {
 		handler,
 		map[string]interface{}{"channel": map[string]string{"id": "1234"}},
 		`{
-			"url": "${BASE_URL}/you-got-message/room/{{.channel.id}}", 
+			"url": "${BASE_URL}/you-got-message/room/{{.channel.id}}",
 			"retry": {
 				"count": 3,
 				"interval": "1ms",
@@ -209,7 +209,7 @@ func TestClientRetryFailure(t *testing.T) {
 		handler,
 		map[string]interface{}{"channel": map[string]string{"id": "1234"}},
 		`{
-			"url": "${BASE_URL}/you-got-message/room/{{.channel.id}}", 
+			"url": "${BASE_URL}/you-got-message/room/{{.channel.id}}",
 			"retry": {
 				"count": 3,
 				"interval": "1ms",

--- a/server/webhook/outgoing/retry.go
+++ b/server/webhook/outgoing/retry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
@@ -65,7 +64,7 @@ func (r *retry) Do(ctx context.Context, sentryInstance sentry.Sentry, descriptio
 		}
 		if res != nil {
 			// Should read all response body otherwise disrupts keep-alive.
-			if _, copyErr := io.Copy(ioutil.Discard, res.Body); copyErr != nil {
+			if _, copyErr := io.Copy(io.Discard, res.Body); copyErr != nil {
 				logger.Of(ctx).Debugf(logger.CatOutgoingWebhook, "failed to read response body: %w", copyErr)
 			}
 			if closeErr := res.Body.Close(); closeErr != nil {


### PR DESCRIPTION
* updated Go version to v1.19.1 which includes security update.
* removed io/ioutil which has been deprecated in Go 1.16.

CI/CD example(including tag-release):
https://github.com/to-lz1/dsps/actions